### PR TITLE
Markdown: Support gist elements

### DIFF
--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -63,5 +63,10 @@ describe Medium::Post::Paragraph do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 4, "text": "", "layout": 3, "href": "https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy", "markups": [], "metadata":{"id": "1*NVLl4oVmMQtumKL-DVV1rA.png"}}})
       subject.to_md.should eq("[![](./assets/1*NVLl4oVmMQtumKL-DVV1rA.png)](https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy)")
     end
+
+    it "render iframe inline" do
+      subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 11, "text": "", "markups": [], "iframe":{"mediaResourceId": "e7722acf2886364130e03d2c7ad29de7"}}})
+      subject.to_md.should eq(%{<iframe src="./assets/e7722acf2886364130e03d2c7ad29de7.html"></iframe>})
+    end
   end
 end

--- a/spec/medium/post_spec.cr
+++ b/spec/medium/post_spec.cr
@@ -34,7 +34,7 @@ describe Medium::Post do
   describe "#to_md" do
     it "render full page" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.to_md.size.should eq(2109)
+      subject.to_md.size.should eq(2176)
     end
 
     it "renders header" do
@@ -102,13 +102,13 @@ describe Medium::Post do
     it "render iframe" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[12]
-      paragraph.to_md.should eq("???")
+      paragraph.to_md.should eq("<iframe src=\"./assets/ab24f0b378f797307fddc32f10a99685.html\"></iframe>")
     end
 
     it "render code block" do
       subject = Medium::Post.from_json(post_fixture)
-      paragraph = subject.content.bodyModel.paragraphs[12]
-      paragraph.to_md.should eq("???")
+      paragraph = subject.content.bodyModel.paragraphs[15]
+      paragraph.to_md.should contain(%{```\n[terminal 1]})
     end
   end
 end

--- a/src/medium/client.cr
+++ b/src/medium/client.cr
@@ -7,12 +7,22 @@ require "./client/*"
 module Medium
   class Client
     @http : HTTP::Client?
+    @@default = Medium::Client.new("", "")
 
     include Medium::Connection
     include Medium::Client::Users
     include Medium::Client::Posts
+    include Medium::Client::Media
 
     def initialize(@token : String, @user : String?)
+    end
+
+    def self.default=(client : Medium::Client)
+      @@default = client
+    end
+
+    def self.default
+      @@default
     end
 
     def close

--- a/src/medium/client/media.cr
+++ b/src/medium/client/media.cr
@@ -1,0 +1,10 @@
+# https://medium.com/media/e7722acf2886364130e03d2c7ad29de7
+module Medium
+  class Client
+    module Media
+      def media(id : String)
+        download("/media/" + id)
+      end
+    end
+  end
+end

--- a/src/medium/connection.cr
+++ b/src/medium/connection.cr
@@ -39,5 +39,13 @@ module Medium
 
       JSON.parse(response.body[16..])
     end
+
+    def download(endpoint : String)
+      response = http.exec("GET", endpoint)
+      puts "GET #{endpoint} => #{response.status_code} #{response.status_message}"
+      error = Medium::Error.from_response(response)
+      raise error if error
+      response.body
+    end
   end
 end

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -41,7 +41,14 @@ module Medium
         when 10
           "1. #{@text}"
         when 11
-          "<!-- Embeded content: iframe -->"
+          if @iframe.nil?
+            "<!-- Missing iframe -->"
+          else
+            frame = @iframe.not_nil!
+            "<iframe src=\"./assets/#{frame.mediaResourceId}.html\"></iframe>"
+            # Support Frame mode with inline content. Github does not support it.
+            #"<frame>#{frame.get}</frame>"
+          end
         when 13
           "### #{@text}"
         when 14
@@ -52,9 +59,15 @@ module Medium
       end
 
       class Iframe
+        getter content : String?
+
         JSON.mapping(
           mediaResourceId: String
         )
+
+        def get
+          @content ||= Medium::Client.default.media(mediaResourceId)
+        end
       end
 
       class MixtapeMetadata


### PR DESCRIPTION
Example of article with Gist embeded component: https://jtway.co/capistrano-3-passing-parameters-to-your-task-e22cc9f659c3

In markdown exported document the gist element is missing.

![image](https://user-images.githubusercontent.com/21104/71306342-38739700-23df-11ea-8d82-20b6483e74cc.png)

## Solution

Download a remote content to `assets` folder.
Setup `iframe` tag to point to the asset.

There is a way to use `frame` with inline content. It would be usefull when implemenet inline options. Same way as images.

