### PR TITLE
Markdown: Record author information to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Markdown: Store authors, subtitle, tags and SEO description information (#7, @miry)
 
 ## [0.1.4] - 2019-12-28
 ### Added

--- a/spec/medium/post_spec.cr
+++ b/spec/medium/post_spec.cr
@@ -34,7 +34,7 @@ describe Medium::Post do
   describe "#to_md" do
     it "render full page" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.to_md.size.should eq(2553)
+      subject.to_md.size.should eq(2801)
     end
 
     it "renders header" do
@@ -109,6 +109,23 @@ describe Medium::Post do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[15]
       paragraph.to_md.should contain(%{```\n[terminal 1]})
+    end
+
+    describe "metadata" do
+      it "stores description information in metadata" do
+        subject = Medium::Post.from_json(post_fixture)
+        subject.to_md.should contain(%{description: Sometime I need to open binaries})
+      end
+
+      it "stores subtitle information in metadata" do
+        subject = Medium::Post.from_json(post_fixture)
+        subject.to_md.should contain(%{subtitle: Edit binary files in Linux with Vim})
+      end
+
+      it "stores tags information in metadata" do
+        subject = Medium::Post.from_json(post_fixture)
+        subject.to_md.should contain(%{tags: vim,debug,linux,cracking,hacking})
+      end
     end
   end
 end

--- a/src/medium/post.cr
+++ b/src/medium/post.cr
@@ -7,7 +7,8 @@ module Medium
     JSON.mapping(
       title: String,
       slug: String,
-      content: PostContent
+      content: PostContent,
+      virtuals: PostVirtuals
     )
 
     def format(ext)
@@ -25,7 +26,10 @@ module Medium
       result = "---\n\
       url: #{@url}\n\
       title: #{@title}\n\
+      subtitle: #{subtitle}\n\
       slug: #{@slug}\n\
+      description: #{seo_description}\n\
+      tags: #{tags}\n\
       ---\n\n"
       result +
         @content.bodyModel.paragraphs.map(&.to_md).join("\n\n")
@@ -34,6 +38,19 @@ module Medium
     def to_pretty_json
       @content.to_pretty_json
     end
+
+    def seo_description
+      @content.metaDescription || ""
+    end
+
+    def subtitle
+      @content.subtitle || ""
+    end
+
+    # Comma seprated list of tags
+    def tags
+      @virtuals.tags.join ",", &.slug
+    end
   end
 
   class PostContent
@@ -41,6 +58,12 @@ module Medium
       subtitle: String,
       metaDescription: String?,
       bodyModel: PostBodyModel
+    )
+  end
+
+  class PostVirtuals
+    JSON.mapping(
+      tags: Array(Post::Tag)
     )
   end
 

--- a/src/medium/post/tag.cr
+++ b/src/medium/post/tag.cr
@@ -1,0 +1,9 @@
+module Medium
+  class Post
+    class Tag
+      JSON.mapping(
+        slug: String
+      )
+    end
+  end
+end


### PR DESCRIPTION
Currently there is only support of basic metadata information: url, title, slug.
Require to add Author information