### PR TITLE
Option to download all "clapped" articles of a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Markdown: Store subtitle, tags and SEO description information (#7, @miry)
 - Markdown: Store authors information (@miry)
+- Export user's recommened articles (#2, @miry)
+- Don't raise exceptions for paragraph type 2: with images in background, title and alignment (#2, @miry)
+- Print error messages to STDERR (#2, @miry)
+
+### Changed
+- Create missing subfolders with more than 1 layer (#2, @miry)
 
 ## [0.1.4] - 2019-12-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 # Features
 
 * Discover all articles from user account available in public
+* Allow to download all recommended articles by user
 * Download images used inside article
 * Save posts in markdown format
 
 # Getting Started
-
 
 ## Docker
 
@@ -30,6 +30,12 @@ Docker way to make same job:
 
 ```shell
 $ docker run -v <path to local articles folder>:/posts -it miry/medup -u <user>
+```
+
+Download all articles that user has recommended:
+
+```shell
+$ docker run -v <path to local articles folder>:/posts -it miry/medup -u <user> --recommended -d posts/recommended
 ```
 
 ## Crystal
@@ -123,7 +129,7 @@ curl -s -H "Content-Type: application/json" https://medium.com/@miry/c35b40c499e
 
 4. Stream
 ```shell
-$ curl -s -H "Content-Type: application/json" "https://medium.com/_/api/users/fdf238948af6/profile/stream" | cut -c17-
+$ curl -s -H "Content-Type: application/json" "https://medium.com/_/api/users/fdf238948af6/profile/stream?source=overview" | cut -c17-
 $ curl -s -H "Content-Type: application/json" "https://medium.com/_/api/users/fdf238948af6/profile/stream?limit=100&page=3" | cut -c17- > stream.json
 $ cat stream.json| jq ".payload.references.Post[].title"
 $ cat stream.json| jq ".payload.paging.next"
@@ -132,4 +138,5 @@ $ cat stream.json| jq ".payload.paging.next"
 5. Recommendations
 ```shell
 $ curl -s -H "Content-Type: application/json" https://medium.com/@miry/has-recommended | cut -c17-
+$ curl -s -H "Content-Type: application/json" "https://medium.com/_/api/users/fdf238948af6/profile/stream?source=has-recommended" | cut -c17-
 ```

--- a/spec/fixtures/post_response.json
+++ b/spec/fixtures/post_response.json
@@ -393,6 +393,13 @@
                 "originalHeight": 1304
               },
               "href": "https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy"
+            },
+            {
+              "name": "e1c8",
+              "type": 2,
+              "text": "The Title with image",
+              "markups": [],
+              "alignment": 2
             }
           ],
           "sections": [

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -44,6 +44,11 @@ describe Medium::Post::Paragraph do
       subject.to_md.should eq("it should be cross distributive solution")
     end
 
+    it "render title" do
+      subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 2, "text": "render title with picture", "markups": [], "alignment": 2}})
+      subject.to_md.should eq("# render title with picture")
+    end
+
     it "render code block" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 8, "text": "puts hello", "markups": []}})
       subject.to_md.should eq("```\nputs hello\n```")

--- a/spec/medium/post_spec.cr
+++ b/spec/medium/post_spec.cr
@@ -19,7 +19,7 @@ describe Medium::Post do
 
     it "setups content" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.content.bodyModel.paragraphs.size.should eq(21)
+      subject.content.bodyModel.paragraphs.size.should eq(22)
     end
   end
 
@@ -34,7 +34,7 @@ describe Medium::Post do
   describe "#to_md" do
     it "render full page" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.to_md.size.should eq(2801)
+      subject.to_md.size.should eq(2825)
     end
 
     it "renders header" do
@@ -109,6 +109,13 @@ describe Medium::Post do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[15]
       paragraph.to_md.should contain(%{```\n[terminal 1]})
+    end
+
+    it "understands alignment attribute" do
+      # Original: https://medium.com/@jico/the-fine-art-of-javascript-error-tracking-bc031f24c659
+      subject = Medium::Post.from_json(post_fixture)
+      paragraph = subject.content.bodyModel.paragraphs[21]
+      paragraph.to_md.should contain(%{# The Title with image})
     end
 
     describe "metadata" do

--- a/src/medium/post.cr
+++ b/src/medium/post.cr
@@ -63,7 +63,7 @@ module Medium
 
   class PostContent
     JSON.mapping(
-      subtitle: String,
+      subtitle: String?,
       metaDescription: String?,
       bodyModel: PostBodyModel
     )

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -13,6 +13,7 @@ module Medium
           iframe:          Iframe?,
           mixtapeMetadata: MixtapeMetadata?,
           href:            String?,
+          alignment:       Int64?,
         },
         strict: true
       )
@@ -21,6 +22,8 @@ module Medium
         case @type
         when 1
           markup
+        when 2
+          "# #{markup}"
         when 3
           "# #{markup}"
         when 4

--- a/src/medup/command.cr
+++ b/src/medup/command.cr
@@ -6,12 +6,14 @@ module Medup
       token = ENV.fetch("MEDIUM_TOKEN", "")
       user = nil
       dist = ::Medup::Tool::DIST_PATH
+      source = ::Medup::Tool::SOURCE_AUTHOR_POSTS
       exit = false
 
       OptionParser.parse do |parser|
         parser.banner = "Usage: medup [arguments]"
         parser.on("-u USER", "--user=USER", "Medium author username. E.g: miry") { |u| user = u }
         parser.on("-d DIRECTORY", "--directory=DIRECTORY", "Path to local directory where articles should be dumped. Default: ./posts") { |d| dist = d }
+        parser.on("-r", "--recommended", "Export all posts to wich user clapped / has recommended") { source = ::Medup::Tool::SOURCE_RECOMMENDED_POSTS }
         parser.on("-h", "--help", "Show this help") { puts parser; exit = true }
         parser.on("-v", "--version", "Print current version") { puts ::Medup::VERSION; exit = true }
 
@@ -22,7 +24,7 @@ module Medup
 
       return if exit
 
-      tool = ::Medup::Tool.new(token: token, user: user, dist: dist)
+      tool = ::Medup::Tool.new(token: token, user: user, dist: dist, source: source)
       tool.backup
       tool.close
     end


### PR DESCRIPTION
This way you could add a cronjob that is looking for new articles you clapped.
Like a download queue. :wink: 

Maybe there should be two variants of it:
1. naïvely overwrite everything in case it was already downloaded (i.e. `--update`?)
2. just download articles that aren't already there (would probably a better default)