### PR TITLE
Export in markdown by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export user's recommened articles (#2, @miry)
 - Don't raise exceptions for paragraph type 2: with images in background, title and alignment (#2, @miry)
 - Print error messages to STDERR (#2, @miry)
+- Specify import format via command line (#23, @miry)
 
 ### Changed
 - Create missing subfolders with more than 1 layer (#2, @miry)

--- a/src/medup/command.cr
+++ b/src/medup/command.cr
@@ -6,6 +6,7 @@ module Medup
       token = ENV.fetch("MEDIUM_TOKEN", "")
       user = nil
       dist = ::Medup::Tool::DIST_PATH
+      format = ::Medup::Tool::MARKDOWN_FORMAT
       source = ::Medup::Tool::SOURCE_AUTHOR_POSTS
       exit = false
 
@@ -13,6 +14,14 @@ module Medup
         parser.banner = "Usage: medup [arguments]"
         parser.on("-u USER", "--user=USER", "Medium author username. E.g: miry") { |u| user = u }
         parser.on("-d DIRECTORY", "--directory=DIRECTORY", "Path to local directory where articles should be dumped. Default: ./posts") { |d| dist = d }
+        parser.on("-f FORMAT", "--format=FORMAT", "Specify the document format. Available options: md or json. Default: md") do |f|
+          format = f
+          unless [::Medup::Tool::MARKDOWN_FORMAT, ::Medup::Tool::JSON_FORMAT].includes?(format)
+            puts "Unknown format option: #{format}"
+            puts parser
+            exit = true
+          end
+        end
         parser.on("-r", "--recommended", "Export all posts to wich user clapped / has recommended") { source = ::Medup::Tool::SOURCE_RECOMMENDED_POSTS }
         parser.on("-h", "--help", "Show this help") { puts parser; exit = true }
         parser.on("-v", "--version", "Print current version") { puts ::Medup::VERSION; exit = true }
@@ -24,9 +33,11 @@ module Medup
 
       return if exit
 
-      tool = ::Medup::Tool.new(token: token, user: user, dist: dist, source: source)
+      tool = ::Medup::Tool.new(token: token, user: user, dist: dist, format: format, source: source)
       tool.backup
       tool.close
+    rescue ex : Exception
+      STDERR.puts "ERROR: #{ex.inspect}"
     end
   end
 end

--- a/src/medup/tool.cr
+++ b/src/medup/tool.cr
@@ -5,14 +5,17 @@ module Medup
     DIST_PATH                = "./posts"
     SOURCE_AUTHOR_POSTS      = "overview"
     SOURCE_RECOMMENDED_POSTS = "has-recommended"
+    MARKDOWN_FORMAT          = "md"
+    JSON_FORMAT              = "json"
 
     user : String?
 
-    def initialize(token : String?, @user : String?, dist : String?, source : String?)
+    def initialize(token : String?, @user : String?, dist : String?, format : String?, source : String?)
       @client = Medium::Client.new(token, @user)
       Medium::Client.default = @client
       @dist = (dist || DIST_PATH).as(String)
       @source = (source || SOURCE_AUTHOR_POSTS).as(String)
+      @format = (format || MARKDOWN_FORMAT).as(String)
     end
 
     def backup
@@ -31,8 +34,7 @@ module Medup
 
     def process_post(post_id : String)
       post = @client.post(post_id)
-      save(post, "md")
-      save(post, "json")
+      save(post, @format)
       save_assets(post)
     rescue ex : Exception
       STDERR.puts "ERROR: #{ex.inspect}"


### PR DESCRIPTION
There are 2  formats stored in result folder. It does not usefull for users, that expect only one format. 

Choose format via argument `--format`