### PR TITLE
Release: Build linuxbrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@
 
 # Getting Started
 
+## Homebrew
+
+Install `medup` tool to the MacOS or Linux via Hombrew:
+
+
+```shell
+$ brew tap miry/medup
+$ brew install medup
+```
+
+Run export command for **Medium** author *miry* and save articles to local folder:
+
+```shell
+$ medup -u miry -d .
+```
+
 ## Docker
 
 Docker way to make same job:


### PR DESCRIPTION
There are different linux and macos delivery options. One common tool is Homebrew.
It requires to create own Tap repo with specifications how to build app.