### PR TITLE
Add option to embed image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM crystallang/crystal:0.35.1 as builder
 
 WORKDIR /app
 COPY ./shard.yml /app/
-RUN shards install
+RUN shards install --production -v
 
 COPY . /app/
 RUN shards build --production -v

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Run export command for **Medium** author *miry* and save articles to local folde
 
 ```shell
 $ medup -u miry -d .
+$ medup -d . https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094
 ```
 
 ## Docker
@@ -89,7 +90,8 @@ In the directory, you can find 2 format of files: `.json` and `.md`.
 - *JSON* format is the raw, what *Medium* returns.
 - *Markdown* format is simple implementation of block formated text.
 
-Images and `IFRAME` content are located in `posts/assets`.
+Images encoded in the result document.
+`IFRAME` content are located in `posts/assets`.
 
 ## Markdown
 

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,6 @@
+version: 2.0
+shards:
+  webmock:
+    git: https://github.com/manastech/webmock.cr.git
+    version: 0.13.0+git.commit.bb3eab30f6c7d1fdc0a7ff14cd136d68e860d1a7
+

--- a/shard.yml
+++ b/shard.yml
@@ -14,3 +14,8 @@ targets:
 crystal: 0.35.1
 
 license: LGPL-3.0
+
+development_dependencies:
+  webmock:
+    github: manastech/webmock.cr
+    branch: master

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -11,82 +11,85 @@ describe Medium::Post::Paragraph do
   describe "#to_md" do
     it "should render header" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 3, "text": "Modify binary files with VIM", "markups": []}})
-      subject.to_md.should eq("# Modify binary files with VIM")
+      subject.to_md[0].should eq("# Modify binary files with VIM")
     end
 
     it "renders blockquotes" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 6, "text": "TLDR text", "markups": []}})
-      subject.to_md.should eq("> TLDR text")
+      subject.to_md[0].should eq("> TLDR text")
     end
 
     it "renders blockquotes second style" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 7, "text": "TLDR text", "markups": []}})
-      subject.to_md.should eq(">> TLDR text")
+      subject.to_md[0].should eq(">> TLDR text")
     end
 
     it "renders images" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 4, "text": "Photo", "layout": 3, "metadata":{"id":"0*FbFs8aNmqNLKw4BM"}, "markups": []}})
-      subject.to_md.should eq("![Photo](./assets/0*FbFs8aNmqNLKw4BM)")
+      content, assets = subject.to_md
+      content.should eq("![Photo][image_ref_MCpGYkZzOGFObXFOTEt3NEJN]")
+      assets.should match(/^\[image_ref_MCpGYkZzOGFObXFOTEt3NEJN\]:/)
     end
 
     it "render number list" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 10, "text": "it should be cross distributive solution", "markups": []}})
-      subject.to_md.should eq("1. it should be cross distributive solution")
+      subject.to_md[0].should eq("1. it should be cross distributive solution")
     end
 
     it "render unordered list" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 9, "text": "it should be cross distributive solution", "markups": []}})
-      subject.to_md.should eq("* it should be cross distributive solution")
+      subject.to_md[0].should eq("* it should be cross distributive solution")
     end
 
     it "render text" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 1, "text": "it should be cross distributive solution", "markups": []}})
-      subject.to_md.should eq("it should be cross distributive solution")
+      subject.to_md[0].should eq("it should be cross distributive solution")
     end
 
     it "render title" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 2, "text": "render title with picture", "markups": [], "alignment": 2}})
-      subject.to_md.should eq("# render title with picture")
+      subject.to_md[0].should eq("# render title with picture")
     end
 
     it "render code block" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 8, "text": "puts hello", "markups": []}})
-      subject.to_md.should eq("```\nputs hello\n```")
+      subject.to_md[0].should eq("```\nputs hello\n```")
     end
 
     it "render small header" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 13, "text": "Help", "markups": []}})
-      subject.to_md.should eq("### Help")
+      subject.to_md[0].should eq("### Help")
     end
 
     it "render link references" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 14, "text": "Socket::Addrinfo", "markups": [], "mixtapeMetadata": {"mediaResourceId": "7f3accd276b8655a927e5d50f276d49d","href":"https://crystal-lang.org/api/0.31.0/Socket/Addrinfo.html"}}})
-      subject.to_md.should eq("https://crystal-lang.org/api/0.31.0/Socket/Addrinfo.html")
+      subject.to_md[0].should eq("https://crystal-lang.org/api/0.31.0/Socket/Addrinfo.html")
     end
 
     it "render image with link" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 4, "text": "", "layout": 3, "href": "https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy", "markups": [], "metadata":{"id": "1*NVLl4oVmMQtumKL-DVV1rA.png"}}})
-      subject.to_md.should eq("[![](./assets/1*NVLl4oVmMQtumKL-DVV1rA.png)](https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy)")
+      content, assets = subject.to_md
+      content.should eq("[![][image_ref_MSpOVkxsNG9WbU1RdHVtS0wtRFZWMXJBLnBuZw==]](https://asciinema.org/a/5diw0wwk6vbbovnqrk5sh1soy)")
     end
 
     it "render iframe inline" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 11, "text": "", "markups": [], "iframe":{"mediaResourceId": "e7722acf2886364130e03d2c7ad29de7"}}})
-      subject.to_md.should eq(%{<iframe src="./assets/e7722acf2886364130e03d2c7ad29de7.html"></iframe>})
+      subject.to_md[0].should eq(%{<iframe src="./assets/e7722acf2886364130e03d2c7ad29de7.html"></iframe>})
     end
 
     it "renders inline code block" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 6, "text": "TL;DR xxd ./bin/app | vim — and :%!xxd -r > ./bin/new_app", "markups": [{"type": 10,"start": 6,"end": 27},{"type": 10,"start": 32,"end": 57}]}})
-      subject.to_md.should eq("> TL;DR `xxd ./bin/app | vim —` and `:%!xxd -r > ./bin/new_app`")
+      subject.to_md[0].should eq("> TL;DR `xxd ./bin/app | vim —` and `:%!xxd -r > ./bin/new_app`")
     end
 
     it "renders bold link" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 6, "text": "My xxd in the world.", "markups": [{"type": 3, "start": 3,"end": 6, "href": "http://example.com"},{"type": 1,"start": 3,"end": 6}]}})
-      subject.to_md.should eq("> My [**xxd**](http://example.com) in the world.")
+      subject.to_md[0].should eq("> My [**xxd**](http://example.com) in the world.")
     end
 
     it "skip render background image" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 15, "text": "picture by me", "markups": [{"type": 3, "start": 11,"end": 15, "href": "http://example.com", "title": "", "rel": "", "anchorType": 0}]}})
-      subject.to_md.should eq("")
+      subject.to_md[0].should eq("")
     end
   end
 end

--- a/spec/medium/post_spec.cr
+++ b/spec/medium/post_spec.cr
@@ -44,88 +44,88 @@ describe Medium::Post do
   describe "#to_md" do
     it "render full page" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.to_md.size.should eq(2825)
+      subject.to_md.size.should eq(3042)
     end
 
     it "renders header" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[0]
-      paragraph.to_md.should eq("# Modify binary files with VIM")
+      paragraph.to_md[0].should eq("# Modify binary files with VIM")
     end
 
     it "renders blockquotes" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[1]
-      paragraph.to_md.should eq("> TL;DR `xxd ./bin/app | vim —` and `:%!xxd -r > ./bin/new_app`")
+      paragraph.to_md[0].should eq("> TL;DR `xxd ./bin/app | vim —` and `:%!xxd -r > ./bin/new_app`")
     end
 
     it "renders image" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[2]
-      paragraph.to_md.should eq("![Photo by Markus Spiske on Unsplash](./assets/0*FbFs8aNmqNLKw4BM)")
+      paragraph.to_md[0].should eq("![Photo by Markus Spiske on Unsplash][image_ref_MCpGYkZzOGFObXFOTEt3NEJN]")
     end
 
     describe "paragraph text" do
       it "renders content with capital letter" do
         subject = Medium::Post.from_json(post_fixture)
         paragraph = subject.content.bodyModel.paragraphs[3]
-        paragraph.to_md.should contain("When I was a student")
+        paragraph.to_md[0].should contain("When I was a student")
       end
 
       it "renders content with links" do
         subject = Medium::Post.from_json(post_fixture)
         paragraph = subject.content.bodyModel.paragraphs[3]
-        paragraph.to_md.should contain("like [Total Commander](https://www.ghisler.com/) or [FAR manager](https://www.farmanager.com/)")
+        paragraph.to_md[0].should contain("like [Total Commander](https://www.ghisler.com/) or [FAR manager](https://www.farmanager.com/)")
       end
 
       it "renders content with bold text with link" do
         subject = Medium::Post.from_json(post_fixture)
         paragraph = subject.content.bodyModel.paragraphs[7]
-        paragraph.to_md.should contain("I came to: [**xxd**](http://vim.wikia.com/wiki/Hex_dump)")
+        paragraph.to_md[0].should contain("I came to: [**xxd**](http://vim.wikia.com/wiki/Hex_dump)")
       end
 
       it "renders content with inline code block" do
         subject = Medium::Post.from_json(post_fixture)
         paragraph = subject.content.bodyModel.paragraphs[7]
-        paragraph.to_md.should contain(%{of `vim-common` package})
+        paragraph.to_md[0].should contain(%{of `vim-common` package})
       end
     end
 
     it "renders numered list first" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[5]
-      paragraph.to_md.should eq("1. it should be cross distributive solution")
+      paragraph.to_md[0].should eq("1. it should be cross distributive solution")
     end
 
     it "renders numered list second" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[6]
-      paragraph.to_md.should eq("1. should be easy to use with Vim (as main my editor for linux machines)")
+      paragraph.to_md[0].should eq("1. should be easy to use with Vim (as main my editor for linux machines)")
     end
 
     pending "render split" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[12]
-      paragraph.to_md.should eq("---")
+      paragraph.to_md[0].should eq("---")
     end
 
     it "render iframe" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[12]
-      paragraph.to_md.should eq("<iframe src=\"./assets/ab24f0b378f797307fddc32f10a99685.html\"></iframe>")
+      paragraph.to_md[0].should eq("<iframe src=\"./assets/ab24f0b378f797307fddc32f10a99685.html\"></iframe>")
     end
 
     it "render code block" do
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[15]
-      paragraph.to_md.should contain(%{```\n[terminal 1]})
+      paragraph.to_md[0].should contain(%{```\n[terminal 1]})
     end
 
     it "understands alignment attribute" do
       # Original: https://medium.com/@jico/the-fine-art-of-javascript-error-tracking-bc031f24c659
       subject = Medium::Post.from_json(post_fixture)
       paragraph = subject.content.bodyModel.paragraphs[21]
-      paragraph.to_md.should contain(%{# The Title with image})
+      paragraph.to_md[0].should contain(%{# The Title with image})
     end
 
     describe "metadata" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,14 @@
 require "spec"
+require "webmock"
+
 require "../src/medup"
+
+Spec.before_suite do
+  WebMock.stub(:get, "https://miro.medium.com/0*FbFs8aNmqNLKw4BM")
+    .to_return(body: "some binary content")
+  WebMock.stub(:get, "https://miro.medium.com/1*NVLl4oVmMQtumKL-DVV1rA.png")
+    .to_return(body: "some binary content")
+end
 
 def fixtures(name)
   raw = File.read(File.join("spec", "fixtures", name))

--- a/src/medium/post.cr
+++ b/src/medium/post.cr
@@ -39,8 +39,13 @@ module Medium
       end
 
       result += "---\n\n"
-      result +
-        @content.bodyModel.paragraphs.map(&.to_md).join("\n\n")
+      assets = "\n"
+      @content.bodyModel.paragraphs.map do |paragraph|
+        content, footer = paragraph.to_md
+        result += content + "\n\n"
+        assets += footer + "\n" unless footer.empty?
+      end
+      result + assets
     end
 
     def to_pretty_json

--- a/src/medup/tool.cr
+++ b/src/medup/tool.cr
@@ -104,11 +104,6 @@ module Medup
       # puts post.to_pretty_json
       post.content.bodyModel.paragraphs.each do |paragraph|
         case paragraph.type
-        when 4
-          metadata = paragraph.metadata
-          if !metadata.nil?
-            download_image(metadata.id)
-          end
         when 11
           iframe = paragraph.iframe
           if !iframe.nil?
@@ -126,20 +121,6 @@ module Medup
 
     def download_iframe(name : String)
       download_to_assets("https://medium.com/media/#{name}", name + ".html")
-    end
-
-    def download_url(href)
-      uri = URI.parse href
-      name = "#{uri.host}_#{uri.path}".gsub(/[\@\/]+/, "_")
-      filepath = File.join(@dist_path, "assets", name)
-
-      return if File.exists?(filepath)
-
-      puts "Download #{href} file to #{filepath}"
-
-      HTTP::Client.get(href) do |response|
-        File.write(filepath, response.body_io)
-      end
     end
 
     def download_to_assets(src, filename)


### PR DESCRIPTION
There is an option to show images in markdown, with inline embeded images with data attribute.

Proposed by @alexanderadam:
It is possible to [inline images with Markdown](https://medium.com/markdown-monster-blog/getting-images-into-markdown-documents-and-weblog-posts-with-markdown-monster-9ec6f353d8ec) (and also HTML) by converting it into base64:

For example
```markdown
[image_ref_a32ff4ads]: data:image/png;base64,iVBORw0KGgoAAAANSUhEke0…RS12D==
```

This way you would get a single file for a single medium article.