### PR TITLE
Emoji breaks markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Skip download assets images without option `--assets-images` (@miry)
+- Emoji breaks markdown rendering (#34, @miry, @clawfire)
 
 ## [0.2.0] - 2022-03-20
 ### Changed
 - Use crystal lang 1.3.2 (#31, @miry)
 
 ### Added
-- Export posts from a publication with option `--publication=NAME` (#31, @miry)
-- Allow to save images to assets folder with option `--assets-images` (#33, @miry)
+- Export posts from a publication with option `--publication=NAME` (#31, @miry, @clawfire)
+- Allow to save images to assets folder with option `--assets-images` (#33, @miry, @clawfire)
 
 ## [0.1.10] - 2021-04-17
 ### Added

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -57,6 +57,30 @@ describe Medium::Post::Paragraph do
       subject.to_md[0].should eq("# render title with picture")
     end
 
+    it "render title with links" do
+      entity_raw = %{
+        {
+          "name": "2612",
+          "type": 13,
+          "text": "🇺🇦 JetThoughts: REsize Amazon EBS volumes without a reboot",
+          "markups": [
+            {
+              "type": 3,
+              "start": 0,
+              "end": 16,
+              "href": "https://jtway.co/resize-amazon-ebs-volumes-without-a-reboot-ca118b010b44",
+              "title": "",
+              "rel": "",
+              "anchorType": 0
+            }
+          ]
+        }
+      }
+
+      subject = Medium::Post::Paragraph.from_json(entity_raw)
+      subject.to_md[0].should eq("### [🇺🇦 JetThoughts](https://jtway.co/resize-amazon-ebs-volumes-without-a-reboot-ca118b010b44): REsize Amazon EBS volumes without a reboot")
+    end
+
     it "render code block" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 8, "text": "puts hello", "markups": []}})
       subject.to_md[0].should eq("```\nputs hello\n```")

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -105,8 +105,8 @@ module Medium
 
         result : String = ""
         _markups = @markups
-        return result if markups.nil?
-        markups.not_nil!.each do |m|
+        return result if _markups.nil?
+        _markups.each do |m|
           if open_elements.has_key?(m.start)
             open_elements[m.start] << m
           else
@@ -121,9 +121,13 @@ module Medium
         end
 
         @text += " "
-        @text.each_char_with_index do |c, i|
-          if close_elements.has_key?(i)
-            close_elements[i].each do |m|
+        char_index = 0
+        # Grapheme is an experimental feature from Crystal to return symbols as
+        # rendered, instead of static width bytes. It helpes to easy identify
+        # emoji symbols chain.
+        @text.each_grapheme do |symbol|
+          if close_elements.has_key?(char_index)
+            close_elements[char_index].each do |m|
               case m.type
               when 1 # bold
                 result += "**"
@@ -140,8 +144,8 @@ module Medium
             end
           end
 
-          if open_elements.has_key?(i)
-            open_elements[i].each do |m|
+          if open_elements.has_key?(char_index)
+            open_elements[char_index].each do |m|
               case m.type
               when 1 # bold
                 result += "**"
@@ -157,7 +161,9 @@ module Medium
             end
           end
 
-          result += c
+          result += symbol.to_s
+          # Medium count each emoji symbol as 4 bytes, when Crystal uses 2 bytes.
+          char_index += symbol.size == 1 ? 1 : symbol.size * 2
         end
 
         result.rchop


### PR DESCRIPTION
@clawfire reported:

I have an emoji in a title tag which have a link on it, resulting into an error in rendering: 

```markdown
### [🇫🇷 Microsoft Veut Concurrencer Amazon En Éliminant Les Caisses Des Supermarchés
```

Source article: https://medium.com/smileinnovation/smile-innovations-watch-3-6e0effb1099b
Exported File: 
[2018-06-25-smile-innovations-watch-3.md](https://github.com/miry/medup/files/8332536/2018-06-25-smile-innovations-watch-3.md)

Expected:

```markdown
### [🇫🇷 Microsoft Veut Concurrencer Amazon En Éliminant Les Caisses Des Supermarchés](https://www.forbes.fr/technologie/microsoft-veut-concurrencer-amazon-en-eliminant-les-caisses-des-supermaches/?utm_campaign=Revue%20newsletter&utm_medium=Newsletter&utm_source=Smile%20Innovation%27s%20Watch)
```

Actual:

```markdown
### [🇫🇷 Microsoft Veut Concurrencer Amazon En Éliminant Les Caisses Des Supermarchés
```