### PR TITLE
Detect target base on patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add integration tests to test command line output (@miry)
+- Extract targets(user, publication, single post) base on pattern. Download articles for different targets in same process. (#36, @miry)
 
 ## [0.2.1] - 2022-03-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,15 +31,13 @@ medup https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-
 Export all articles written by single author to special folder `posts/miry`
 
 ```shell
-medium -u miry -d posts/miry
+medup -u miry -d posts/miry
 ```
 
-## Publication's posts
-
-Export all articles written by single author to special folder `posts/miry`
+Alternative:
 
 ```shell
-medium -p jetthoughts -d posts/jetthoughts
+medup @miry -d posts/miry
 ```
 
 ## User's recommendations
@@ -47,13 +45,47 @@ medium -p jetthoughts -d posts/jetthoughts
 Export all articles recommended by `miry`:
 
 ```shell
-medium -u miry -d posts/recommendations -r
+medup -u miry -d posts/recommendations -r
 ```
+
+Alternative:
+
+```shell
+medup @miry -d posts/recommendations -r
+```
+
+## Publication's posts
+
+Export all articles written by single author to special folder `posts/miry`
+
+```shell
+medup -p jetthoughts -d posts/jetthoughts
+```
+
+Alternative:
+
+```shell
+medup jetthoughts -d posts/jetthoughts
+```
+
+## Mix
+
+```shell
+medup -u miry @pftg -p jetthoughts notes-and-tips-in-full-stack-development https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094
+```
+
+It would download all articles for:
+1. user `@miry`
+1. user `@pftg`
+1. publication `jetthoughts`
+1. publication `notes-and-tips-in-full-stack-development`
+1. single post "Medup backups articles"
 
 # Features
 
 * Discover all articles from user account available in public
 * Allow to download all recommended articles by user
+* Discover all articles from publisher, that available in public
 * Download images used inside article
 * Save posts in markdown format
 * Convert a single article in markdown format

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -12,7 +12,7 @@ describe "CommandLine", tags: "e2e" do
 
     it "prints help" do
       actual = run_with ["--help"]
-      actual[0].should contain("Usage:\n  medup [arguments] [article url]\n\n")
+      actual[0].should contain("Usage:\n  medup [arguments] [@user or publication name or url]\n\n")
     end
 
     it "handles unknown options" do
@@ -163,7 +163,7 @@ describe "CommandLine", tags: "e2e" do
       actual.should contain("2022-03-25-i-was-born-into-a-military-family-now-im-making-bulletproof-vests-for-ukraine.md")
     end
 
-    it "download posts from user without option", focus: true do
+    it "download posts from user without option" do
       actual = run_with ["@kristinazakharchenko"]
       actual[0].should contain(%{GET /@kristinazakharchenko?format=json => 200 OK})
       actual[0].should contain(%{GET /_/api/users/a002e103d8f7/profile/stream?format=json&limit=100&source=overview => 200 OK})

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -163,6 +163,17 @@ describe "CommandLine", tags: "e2e" do
       actual.should contain("2022-03-25-i-was-born-into-a-military-family-now-im-making-bulletproof-vests-for-ukraine.md")
     end
 
+    it "download posts from user without option", focus: true do
+      actual = run_with ["@kristinazakharchenko"]
+      actual[0].should contain(%{GET /@kristinazakharchenko?format=json => 200 OK})
+      actual[0].should contain(%{GET /_/api/users/a002e103d8f7/profile/stream?format=json&limit=100&source=overview => 200 OK})
+      actual[1].should eq("")
+
+      actual = Dir.new("posts").entries
+      actual.should contain("assets")
+      actual.should contain("2022-03-25-i-was-born-into-a-military-family-now-im-making-bulletproof-vests-for-ukraine.md")
+    end
+
     it "download posts from user recommendations" do
       actual = run_with ["--user", "doctorow", "--recommended"]
       actual[0].should contain(%{GET /@doctorow?format=json => 200 OK})

--- a/spec/medup/command_spec.cr
+++ b/spec/medup/command_spec.cr
@@ -13,8 +13,8 @@ describe Medup::Command do
     end
 
     it "detect posts with jetthoughts" do
-      actual = Medup::Command.extract_targets(["https://example.com/oops"])
-      actual[:articles].should eq(["https://example.com/oops"])
+      actual = Medup::Command.extract_targets(["https://example.com/oops", "http://example.com/oops"])
+      actual[:articles].should eq(["https://example.com/oops", "http://example.com/oops"])
     end
 
     it "mix targets" do

--- a/spec/medup/command_spec.cr
+++ b/spec/medup/command_spec.cr
@@ -1,0 +1,28 @@
+require "../spec_helper"
+
+describe Medup::Command do
+  describe ".extract_targets" do
+    it "detect user with @" do
+      actual = Medup::Command.extract_targets(["@miry"])
+      actual[:users].should contain("miry")
+    end
+
+    it "detect publication with jetthoughts" do
+      actual = Medup::Command.extract_targets(["jetthoughts"])
+      actual[:publications].should contain("jetthoughts")
+    end
+
+    it "detect posts with jetthoughts" do
+      actual = Medup::Command.extract_targets(["https://example.com/oops"])
+      actual[:articles].should eq(["https://example.com/oops"])
+    end
+
+    it "mix targets" do
+      args = ["https://example.com/oops", "jetthoughts", "@miry", "foo"]
+      actual = Medup::Command.extract_targets(args)
+      actual[:users].should eq(["miry"])
+      actual[:publications].should eq(["jetthoughts", "foo"])
+      actual[:articles].should eq(["https://example.com/oops"])
+    end
+  end
+end

--- a/src/medup/command.cr
+++ b/src/medup/command.cr
@@ -16,7 +16,7 @@ module Medup
       should_exit = false
 
       parser = OptionParser.parse do |parser|
-        parser.banner = "Usage:\n  medup [arguments] [article url]\n"
+        parser.banner = "Usage:\n  medup [arguments] [@user or publication name or url]\n"
         parser.on("-u USER", "--user=USER", "Medium author username. Download alrticles for this author. E.g: miry") { |u| user = u }
         parser.on("-p PUBLICATION", "--publication=PUBLICATION", "Medium publication slug. Download articles for the publication. E.g: jetthoughts") { |pub| publication = pub }
         parser.on("-d DIRECTORY", "--directory=DIRECTORY", "Path to local directory where articles should be dumped. Default: ./posts") { |d| dist = d }
@@ -125,7 +125,7 @@ module Medup
         case word
         when /^\@.*/
           users << word[1..]
-        when /^https:\/\/.*/
+        when /^https?:\/\/.*/
           articles << word
         else
           publications << word

--- a/src/medup/command.cr
+++ b/src/medup/command.cr
@@ -77,5 +77,24 @@ module Medup
       STDERR.puts "See 'medup --help' for usage."
       exit(1)
     end
+
+    def self.extract_targets(input)
+      users = Array(String).new
+      publications = Array(String).new
+      articles = Array(String).new
+
+      input.each do |word|
+        case word
+        when /^\@.*/
+          users << word[1..]
+        when /^https:\/\/.*/
+          articles << word
+        else
+          publications << word
+        end
+      end
+
+      return {users: users, publications: publications, articles: articles}
+    end
   end
 end

--- a/src/medup/command.cr
+++ b/src/medup/command.cr
@@ -57,20 +57,58 @@ module Medup
 
       return if should_exit
 
-      tool = ::Medup::Tool.new(
-        token: token,
-        user: user,
-        publication: publication,
-        articles: articles,
-        dist: dist,
-        format: format,
-        source: source,
-        update: update,
-        options: options
-      )
+      targets = extract_targets(articles)
 
-      tool.backup
-      tool.close
+      # Backup single posts
+      if targets[:articles].size > 0
+        tool = ::Medup::Tool.new(
+          token: token,
+          user: nil,
+          publication: nil,
+          articles: targets[:articles],
+          dist: dist,
+          format: format,
+          source: source,
+          update: update,
+          options: options
+        )
+        tool.backup
+        tool.close
+      end
+
+      # Backup articles per user
+      (targets[:users] + [user]).compact.each do |u|
+        tool = ::Medup::Tool.new(
+          token: token,
+          user: u,
+          publication: nil,
+          articles: Array(String).new,
+          dist: dist,
+          format: format,
+          source: source,
+          update: update,
+          options: options
+        )
+        tool.backup
+        tool.close
+      end
+
+      # Backup articles per publication
+      (targets[:publications] + [publication]).compact.each do |p|
+        tool = ::Medup::Tool.new(
+          token: token,
+          user: nil,
+          publication: p,
+          articles: Array(String).new,
+          dist: dist,
+          format: format,
+          source: source,
+          update: update,
+          options: options
+        )
+        tool.backup
+        tool.close
+      end
     rescue ex : Exception
       STDERR.puts "error: #{ex.inspect}"
       STDERR.puts ex.inspect_with_backtrace


### PR DESCRIPTION
Detect user, publication or single posts base on argument pattern.
Allow to mix targets and download in same process.