### PR TITLE
Image assets missed extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Custom domain posts returns excpetions, fixed the problem (@miry)
+- Detect downloaded assets' type and add missing extension (#37, @miry)
 
 ### Added
 - Add integration tests to test command line output (@miry)

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -69,11 +69,16 @@ describe "CommandLine", tags: "e2e" do
       actual = run_with ["https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
       actual[0].should contain(%{Posts count: 1})
       actual[0].should contain(%{200 OK})
+      actual[0].should contain(%{GET https://medium.com/media/d0aa4300e50ebcf6d244dd91e836bc5f => 200 OK})
+      actual[0].should contain(%{Create asset ./posts/assets/d0aa4300e50ebcf6d244dd91e836bc5f.html})
       actual[1].should eq("")
 
       actual = Dir.new("posts").entries
       actual.should contain("assets")
       actual.should contain("2020-09-16-medup-backups-articles.md")
+
+      actual = Dir.new("posts/assets").entries
+      actual.should contain("d0aa4300e50ebcf6d244dd91e836bc5f.html")
     end
 
     it "download medium from custom domain" do
@@ -91,11 +96,17 @@ describe "CommandLine", tags: "e2e" do
     it "saves images in assets folder" do
       actual = run_with ["--assets-images", "https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
       actual[0].should contain(%{Posts count: 1})
-      actual[0].should contain(%{Download file https://miro.medium.com/1*CSF4xue7yFfg-9-wxAkDWw.jpeg to ./posts/assets/1*CSF4xue7yFfg-9-wxAkDWw.jpeg})
+      actual[0].should contain(%{GET https://miro.medium.com/1*CSF4xue7yFfg-9-wxAkDWw.jpeg => 200 OK})
+      actual[0].should contain(%{GET https://miro.medium.com/0*LZaURw4xtfA74nu9 => 200 OK})
+      actual[0].should contain(%{GET https://medium.com/media/d0aa4300e50ebcf6d244dd91e836bc5f => 200 OK})
+      actual[0].should contain(%{Create asset ./posts/assets/0*LZaURw4xtfA74nu9.jpeg})
+      actual[0].should contain(%{Create asset ./posts/assets/d0aa4300e50ebcf6d244dd91e836bc5f.html})
       actual[1].should eq("")
 
       actual = Dir.new("posts/assets").entries
       actual.should contain("1*CSF4xue7yFfg-9-wxAkDWw.jpeg")
+      actual.should contain("0*LZaURw4xtfA74nu9.jpeg")
+      actual.should contain("d0aa4300e50ebcf6d244dd91e836bc5f.html")
     end
 
     it "skip existing aritcles" do

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -26,15 +26,18 @@ describe Medium::Post::Paragraph do
 
     it "renders images" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 4, "text": "Photo", "layout": 3, "metadata":{"id":"0*FbFs8aNmqNLKw4BM"}, "markups": []}})
-      content, assets = subject.to_md
+      content, asset_name, assets = subject.to_md
       content.should eq("![Photo][image_ref_MCpGYkZzOGFObXFOTEt3NEJN]")
       assets.should match(/^\[image_ref_MCpGYkZzOGFObXFOTEt3NEJN\]:/)
+      asset_name.should eq("0*FbFs8aNmqNLKw4BM.png")
     end
 
     it "renders images with assets" do
-      subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 4, "text": "Photo", "layout": 3, "metadata":{"id":"0*FbFs8aNmqNLKw4BM.png"}, "markups": []}})
-      content, assets = subject.to_md([::Medup::Options::ASSETS_IMAGE])
+      subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 4, "text": "Photo", "layout": 3, "metadata":{"id":"0*FbFs8aNmqNLKw4BM"}, "markups": []}})
+      content, asset_name, assets = subject.to_md([::Medup::Options::ASSETS_IMAGE])
       content.should eq("![Photo](./assets/0*FbFs8aNmqNLKw4BM.png)")
+      assets.size.should eq(66)
+      asset_name.should eq("0*FbFs8aNmqNLKw4BM.png")
     end
 
     it "render number list" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,10 +4,23 @@ require "webmock"
 require "../src/medup"
 
 Spec.before_suite do
+  io = IO::Memory.new
+  Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=", io)
   WebMock.stub(:get, "https://miro.medium.com/0*FbFs8aNmqNLKw4BM")
-    .to_return(body: "some binary content")
+    .to_return(
+      body: io.to_s,
+      headers: HTTP::Headers{
+        "Content-Type"   => "image/png",
+        "Content-length" => "1",
+      }
+    )
   WebMock.stub(:get, "https://miro.medium.com/1*NVLl4oVmMQtumKL-DVV1rA.png")
-    .to_return(body: "some binary content")
+    .to_return(body: "some binary content", headers: HTTP::Headers{"Content-Type" => "image/png"})
+
+  WebMock.stub(:get, "https://medium.com/media/e7722acf2*886364130e03d2c7ad29de7")
+    .to_return(body: "<div>Iframe example</div>", headers: HTTP::Headers{"Content-Type" => "text/html"})
+  WebMock.stub(:get, "https://medium.com/media/ab24f0b378f797307fddc32f10a99685")
+    .to_return(body: "<div>Iframe example</div>", headers: HTTP::Headers{"Content-Type" => "text/html"})
 end
 
 def fixtures(name)

--- a/src/medium/client/posts.cr
+++ b/src/medium/client/posts.cr
@@ -162,7 +162,7 @@ module Medium
       def post_by_url(url : String)
         response = get(url)
 
-        result = Post.from_json(response["payload"]["value"].to_json)
+        result = Medium::Post.from_json(response["payload"]["value"].to_json)
         result.url = url
 
         creator_id = response["payload"]["value"]["creatorId"].as_s

--- a/src/medium/post.cr
+++ b/src/medium/post.cr
@@ -35,6 +35,7 @@ module Medium
         slug: #{@slug}\n\
         description: #{seo_description}\n\
         tags: #{tags}\n"
+      assets = Hash(String, String).new
 
       unless @user.nil?
         user = @user.not_nil!
@@ -43,13 +44,25 @@ module Medium
       end
 
       result += "---\n\n"
-      assets = "\n"
+      footer = "\n"
+
       @content.bodyModel.paragraphs.map do |paragraph|
-        content, footer = paragraph.to_md(@options)
+        content, asset_name, asset_content = paragraph.to_md(@options)
         result += content + "\n\n"
-        assets += footer + "\n" unless footer.empty?
+        if !asset_content.empty?
+          if paragraph.type == 11 ||
+             (paragraph.type == 4 &&
+             options.includes?(Medup::Options::ASSETS_IMAGE))
+            assets[asset_name] = asset_content
+          else
+            footer += asset_content + "\n"
+          end
+        end
       end
-      result + assets
+
+      result += footer
+
+      return result, assets
     end
 
     def to_pretty_json


### PR DESCRIPTION
Some assets missed extension. 
Need to use https://crystal-lang.org/api/1.4.0/MIME.html to detect the file and add extensions.

Example: https://github.com/miry/medup/pull/33#issuecomment-1076254615

Example how it could be done: https://github.com/smileinnovation/fix-markdown-images/blob/main/fixup_md_img/__init__.py