### PR TITLE
Convert gist frames to block code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Inline gist media as code block inside a result markdown file. (#39, @miry)
+
 ### Added
 - Move most of debug output to logger. Allow to specify the verbosity of output
   with parameter `-v[NUM]`. Previous messages debug messages are appeared

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -71,19 +71,19 @@ describe "CommandLine", tags: "e2e" do
       actual[1].should contain(%{error: could not process http://example.com: unsupported content type text/html})
     end
 
-    it "download medium from medium domain" do
+    it "download medium from medium and gist domain" do
       actual = run_with ["-v4", "https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
       actual[1].should contain(%{Posts count: 1})
-      actual[1].should contain(%{200 OK})
-      actual[1].should contain(%{GET https://medium.com/media/d0aa4300e50ebcf6d244dd91e836bc5f => 200 OK})
-      actual[1].should contain(%{Create asset ./posts/assets/d0aa4300e50ebcf6d244dd91e836bc5f.html})
+      actual[1].should contain(%{GET https://medium.com/@/8bf90179b094?format=json => 200 OK})
+      actual[1].should contain(%{GET https://api.github.com/gists/d7e8a19eb66734fb69cf8ee4c32095bc => 200 OK})
+      actual[1].should contain(%{GET https://miro.medium.com/1*CSF4xue7yFfg-9-wxAkDWw.jpeg => 200 OK})
 
       actual = Dir.new("posts").entries
       actual.should contain("assets")
       actual.should contain("2020-09-16-medup-backups-articles.md")
 
       actual = Dir.new("posts/assets").entries
-      actual.should contain("d0aa4300e50ebcf6d244dd91e836bc5f.html")
+      actual.sort.should eq([".", ".."])
     end
 
     it "download medium from custom domain" do
@@ -102,14 +102,11 @@ describe "CommandLine", tags: "e2e" do
       actual[1].should contain(%{Posts count: 1})
       actual[1].should contain(%{GET https://miro.medium.com/1*CSF4xue7yFfg-9-wxAkDWw.jpeg => 200 OK})
       actual[1].should contain(%{GET https://miro.medium.com/0*LZaURw4xtfA74nu9 => 200 OK})
-      actual[1].should contain(%{GET https://medium.com/media/d0aa4300e50ebcf6d244dd91e836bc5f => 200 OK})
       actual[1].should contain(%{Create asset ./posts/assets/0*LZaURw4xtfA74nu9.jpeg})
-      actual[1].should contain(%{Create asset ./posts/assets/d0aa4300e50ebcf6d244dd91e836bc5f.html})
 
       actual = Dir.new("posts/assets").entries
       actual.should contain("1*CSF4xue7yFfg-9-wxAkDWw.jpeg")
       actual.should contain("0*LZaURw4xtfA74nu9.jpeg")
-      actual.should contain("d0aa4300e50ebcf6d244dd91e836bc5f.html")
     end
 
     it "skip existing aritcles" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,6 +4,8 @@ require "webmock"
 require "../src/medup"
 
 Spec.before_suite do
+  WebMock.reset
+
   io = IO::Memory.new
   Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=", io)
   WebMock.stub(:get, "https://miro.medium.com/0*FbFs8aNmqNLKw4BM")
@@ -19,6 +21,7 @@ Spec.before_suite do
 
   WebMock.stub(:get, "https://medium.com/media/e7722acf2*886364130e03d2c7ad29de7")
     .to_return(body: "<div>Iframe example</div>", headers: HTTP::Headers{"Content-Type" => "text/html"})
+
   WebMock.stub(:get, "https://medium.com/media/ab24f0b378f797307fddc32f10a99685")
     .to_return(body: "<div>Iframe example</div>", headers: HTTP::Headers{"Content-Type" => "text/html"})
 end


### PR DESCRIPTION
Manage to detect gist and download content inside block.
Example of gist https://gist.githubusercontent.com/miry/d7e8a19eb66734fb69cf8ee4c32095bc:

```
  ` ` `
  #!/usr/bin/env bash

  medup -u miry -d ./posts/miry          # Articles written by miry
  medup @miry -d ./posts/miry            # Alternative way to get articles written by miry
  medup -u miry -d ./posts/favorites -r  # Favorite articles of miry (clapped one)
  medup -u miry -d ./posts/miry --update # Update existing exported posts with latest versions of posts
  medup -u miry -d ./posts/miry --assets-images  # Save images to assets folder
  medup -p jetthoughts -d ./posts/jetthoughts # Export Jetthought publication's posts
  medup jetthoughts -d ./posts/jetthoughts # Alternative way to export Jetthought publication's posts
  medup https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094 # Export single article
  medup https://jtway.co/git-minimum-for-effective-project-development-841a0b865ef0 # Export signle article with custom domain
  ` ` `
  [usage.sh view raw](https://gist.githubusercontent.com/miry/d7e8a19eb66734fb69cf8ee4c32095bc/raw/a577b9fc77074f182b16f869035c81a174542399/usage.sh)

```