### PR TITLE
Inline twiter media inside the article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Inline gist media as code block inside a result markdown file. (#39, @miry)
 - Inline youtube media as link instead of iframe. (#42, @miry)
+- Inline twitter media as blockquote instead of iframe. (#44, @miry)
 
 ### Added
 - Move most of debug output to logger. Allow to specify the verbosity of output

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -239,7 +239,7 @@ describe Medium::Post::Paragraph do
       end
 
       describe "youtube" do
-        it "render media gist inline" do
+        it "renders media inline" do
           WebMock.stub(:get, "https://medium.com/media/youtuberesourceid")
             .to_return(
               body: %{
@@ -264,6 +264,43 @@ describe Medium::Post::Paragraph do
             }
           })
           subject.to_md[0].should contain(%{[![Youtube](https://img.youtube.com/vi/30xiI21RraQ/hqdefault.jpg)](https://www.youtube.com/watch?v=30xiI21RraQ)})
+        end
+      end
+
+      describe "twitter", focus: true do
+        it "renders media inline" do
+          WebMock.stub(:get, "https://medium.com/media/twittersourceid")
+            .to_return(
+              body: %{
+                <html>
+                <head>
+                <title>Tweet</title>
+                <meta name="description" content="Message *everything*. https://t.co/Z9tzeOkIvQ">
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+                </head>
+                <body>
+                <blockquote class="twitter-tweet" data-conversation="none" data-align="center" data-dnt="true">
+                <p>&#x200a;&mdash;&#x200a;
+                <a href="https://twitter.com/copyconstruct/status/941461955386122240">@copyconstruct</a></p>
+                </blockquote>
+                <script src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+                </body>
+                </html>
+              },
+              headers: HTTP::Headers{"Content-Type" => "text/html; charset=utf-8"})
+          subject = Medium::Post::Paragraph.from_json(%{
+            {
+              "name": "9169","type": 11,"text": "","markups": [],"layout": 1,
+              "iframe": {
+                "mediaResourceId": "twittersourceid",
+                "iframeWidth": 500, "iframeHeight": 185,
+                "thumbnailUrl": "https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F825614963729272832%2FxbeK0wJV_400x400.jpg&key=a19fcc184b9711e1b4764040d3dc5c07"
+              }
+            }
+          })
+          subject.to_md[0].should contain(%{> Message *everything*. https://t.co/Z9tzeOkIvQ})
+          subject.to_md[0].should contain(%{&#x200a;&mdash;&#x200a;})
+          subject.to_md[0].should contain(%{<a href="https://twitter.com/copyconstruct/status/941461955386122240">@copyconstruct</a>})
         end
       end
     end

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -87,6 +87,8 @@ module Medium
                         result = process_gist_content(media_content)
                       elsif media_content.includes?("schema=youtube")
                         result = process_youtube_content(media_content)
+                      elsif media_content.includes?("https://twitter.com")
+                        result = process_twitter_content(media_content)
                       end
 
                       if result.empty?
@@ -190,6 +192,21 @@ module Medium
           "```\n#{gist["content"]}\n```\n" +
             "> *[#{gist["filename"]} view raw](#{gist["raw_url"]})*"
         end.join("\n")
+      end
+
+      def process_twitter_content(content : String) : String
+        @logger.debug 7, "Processing twitter element"
+        m = content.match(/<meta[^>]*name="description"[^>]*>/m)
+        return "" if m.nil?
+
+        m = m[0].match(/content="(?<tweet>[^"]*)"/m)
+        return "" if m.nil? || m["tweet"].empty?
+
+        result = "> #{m["tweet"]}"
+
+        m = content.match(/<blockquote[^>]*class="twitter-tweet"[^>]*>(?<quote>.*)<\/blockquote>/m)
+        return result if m.nil? || m["quote"].empty?
+        result + "\n> " + m["quote"]
       end
 
       def markup


### PR DESCRIPTION
Convert iframe content to sample blockquote:

## Example 

Original article: [Testing Microservices, the sane way](https://copyconstruct.medium.com/testing-microservices-the-sane-way-9bb31d158c16)

Rendered:

```
> Yep! The whole point of microservices is to enable teams to develop, deploy and scale independently. Yet when it comes to testing, we insist on testing *everything* together by spinning up *identical* environments, contradicting the mainspring of why we even do microservices. https://t.co/Z9tzeOkIvQ
> <p>&#x200a;&mdash;&#x200a;<a href="https://twitter.com/copyconstruct/status/941461955386122240">@copyconstruct</a></p>
```


<img width="1065" alt="image" src="https://user-images.githubusercontent.com/21104/166103422-8fdc1514-8daf-4001-9b12-4b5ddb7935f9.png">
