### PR TITLE
Support Github token to access gist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update article' url tag to get value from response, instead of from commandline
   arguments (@miry)
+- Update the code to use **Context** pattern. Combine in it options, logger and
+  settings. (#47, @miry)
+
+### Added
+- Allow to specify `MEDUP_GITHUB_API_TOKEN` environment variable to increase
+  number of requests to gist. (#47, @miry)
 
 ## [0.4.0] - 2022-04-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Alternative:
 medup jetthoughts -d posts/jetthoughts
 ```
 
+## ENVIRONMENT
+
+* **MEDUP_GITHUB_API_TOKEN**
+  Use this GitHub personal access token when accessing the GitHub Gist.
+
 ## Mix
 
 ```shell
@@ -90,9 +95,10 @@ It would download all articles for:
 * Discover all articles from user account available in public
 * Allow to download all recommended articles by user
 * Discover all articles from publisher, that available in public
-* Download images used inside article
+* Download images used inside article or in `assets` folder
 * Save posts in markdown format
 * Convert a single article in markdown format
+* Extract gists and convert to code blocks
 
 # Getting Started
 

--- a/spec/medium/client/posts_spec.cr
+++ b/spec/medium/client/posts_spec.cr
@@ -3,13 +3,13 @@ require "../../spec_helper"
 describe Medium::Client::Posts do
   describe "#normalize_urls" do
     it "extract id from url with medium host" do
-      client = Medium::Client.new("", "", "", logger)
+      client = Medium::Client.new("", "", logger)
       urls = client.normalize_urls(["https://medium.com/notes-and-tips-in-full-stack-development/crystal-detects-emoji-symbols-in-string-b6759ab94625"])
       urls.should eq(["https://medium.com/@/b6759ab94625"])
     end
 
     it "keep custom domain url" do
-      client = Medium::Client.new("", "", "", logger)
+      client = Medium::Client.new("", "", logger)
       urls = client.normalize_urls(["https://jtway.co/git-minimum-for-effective-project-development-841a0b865ef0"])
       urls.should eq(["https://jtway.co/git-minimum-for-effective-project-development-841a0b865ef0"])
     end

--- a/spec/medium/post_spec.cr
+++ b/spec/medium/post_spec.cr
@@ -46,7 +46,10 @@ describe Medium::Post do
 
     it "render full page without images" do
       subject = Medium::Post.from_json(post_fixture)
-      subject.options = [Medup::Options::ASSETS_IMAGE]
+      settings = ::Medup::Settings.new
+      settings.set_assets_image!
+      subject.ctx = ::Medup::Context.new(settings)
+
       content, assets = subject.to_md
       content.size.should eq(2932)
       assets.keys.should eq([
@@ -79,8 +82,12 @@ describe Medium::Post do
 
     it "renders image in assets" do
       subject = Medium::Post.from_json(post_fixture)
+      settings = ::Medup::Settings.new
+      settings.set_assets_image!
+      ctx = ::Medup::Context.new(settings)
+
       paragraph = subject.content.bodyModel.paragraphs[2]
-      actual = paragraph.to_md([Medup::Options::ASSETS_IMAGE])
+      actual = paragraph.to_md(ctx)
       actual[0].should eq("![Photo by Markus Spiske on Unsplash](./assets/0*FbFs8aNmqNLKw4BM.png)")
       actual[1].should eq("0*FbFs8aNmqNLKw4BM.png")
       actual[2].size.should eq(66)

--- a/src/medium/client.cr
+++ b/src/medium/client.cr
@@ -8,8 +8,9 @@ require "./client/*"
 
 module Medium
   class Client
+    @token : String? = nil
     @http = Hash(String, HTTP::Client).new
-    @@default = Medium::Client.new("", "", "", Logger.new(STDOUT))
+    @@default = Medium::Client.new("", "", Logger.new(STDOUT))
 
     include Medium::Client::Media
     include Medium::Client::Posts
@@ -17,7 +18,7 @@ module Medium
     include Medium::Client::Users
     include Medium::Connection
 
-    def initialize(@token : String, @user : String?, @publication : String?, @logger : Logger)
+    def initialize(@user : String?, @publication : String?, @logger : Logger)
     end
 
     def self.default=(client : Medium::Client)

--- a/src/medium/client/posts.cr
+++ b/src/medium/client/posts.cr
@@ -163,7 +163,6 @@ module Medium
         response = get(url)
 
         result = Medium::Post.from_json(response["payload"]["value"].to_json)
-        result.logger = @logger
 
         creator_id = response["payload"]["value"]["creatorId"].as_s
         result.user = User.from_json(response["payload"]["references"]["User"][creator_id].to_json)

--- a/src/medium/connection_api.cr
+++ b/src/medium/connection_api.cr
@@ -25,7 +25,7 @@ module Medium
 
       _http.before_request do |request|
         request.headers["Content-Type"] = "application/json"
-        request.headers["Authorization"] = "Bearer #{@token}"
+        request.headers["Authorization"] = "Bearer #{@token}" if !@token.empty?
       end
 
       @http = _http

--- a/src/medium/post.cr
+++ b/src/medium/post.cr
@@ -1,14 +1,11 @@
 require "json_mapping"
 
-require "logger"
-
 require "./post/*"
 
 module Medium
   class Post
+    property ctx : ::Medup::Context = ::Medup::Context.new
     property user : Medium::User?
-    property options : Array(Medup::Options) = Array(Medup::Options).new
-    property logger : Logger = Logger.new(STDOUT)
 
     JSON.mapping(
       title: String,
@@ -51,12 +48,11 @@ module Medium
       footer = "\n"
 
       @content.bodyModel.paragraphs.map do |paragraph|
-        content, asset_name, asset_content = paragraph.to_md(@options, @logger)
+        content, asset_name, asset_content = paragraph.to_md(@ctx)
         result += content + "\n\n"
         if !asset_content.empty?
           if paragraph.type == 11 ||
-             (paragraph.type == 4 &&
-             options.includes?(Medup::Options::ASSETS_IMAGE))
+             (paragraph.type == 4 && @ctx.settings.assets_image?)
             assets[asset_name] = asset_content
           else
             footer += asset_content + "\n"

--- a/src/medup/context.cr
+++ b/src/medup/context.cr
@@ -1,0 +1,11 @@
+require "logger"
+
+module Medup
+  class Context
+    property settings : ::Medup::Settings
+    property logger : Logger
+
+    def initialize(@settings = ::Medup::Settings.new, @logger = Logger.new(STDOUT))
+    end
+  end
+end

--- a/src/medup/settings.cr
+++ b/src/medup/settings.cr
@@ -1,0 +1,28 @@
+require "./options"
+
+module Medup
+  struct Settings
+    property medium_token : String?
+    property github_api_token : String?
+    property options : Array(::Medup::Options) = Array(Medup::Options).new
+
+    def initialize
+    end
+
+    def set_update_content!
+      @options << ::Medup::Options::UPDATE_CONTENT
+    end
+
+    def update_content? : Bool
+      @options.includes?(Medup::Options::UPDATE_CONTENT)
+    end
+
+    def set_assets_image!
+      @options << ::Medup::Options::ASSETS_IMAGE
+    end
+
+    def assets_image? : Bool
+      @options.includes? ::Medup::Options::ASSETS_IMAGE
+    end
+  end
+end


### PR DESCRIPTION
Currently gist is limit 60 requests per hour. Make this higher need to setup token to access gist.

Read token from env: `MEDUP_GITHUB_API_TOKEN`.
Request to create a token via page: https://github.com/settings/tokens

Add header: `--header Authorization:\ token\ ******`