### PR TITLE
Allow specify the assets folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to change the download distination for assets with flag `--assets-dir=<DIR>`. (#40, @miry)
+- Allow to change the uri path for assets inside document with `--assets-base-path=<BASE_PATH>`.
+  It help to access assets in case the global assets path or custom directory. (#40, @miry)
 
 ## [0.4.1] - 2022-05-02
 ### Changed

--- a/Rakefile
+++ b/Rakefile
@@ -164,19 +164,13 @@ namespace :demo do
   namespace :medup do
     desc "Sync demo posts"
     task sync: [:build] do
-      sh "#{BIN_PATH} @miry -v7 -d #{DEMO_PATH}/_posts/"
-      sh "#{BIN_PATH} jetthoughts -v7 -d #{DEMO_PATH}/_posts/"
-      mv "#{DEMO_PATH}/_posts/assets", "#{DEMO_PATH}/"
-    end
-
-    desc "Tune posts to Jekyll compatible"
-    task :jekyll_format do
-      sh "sed -i .bak 's/\.\\/assets/\\/assets/g' #{DEMO_PATH}/_posts/*.md"
-      sh "rm #{DEMO_PATH}/_posts/*.bak"
+      medup_options = "-d #{DEMO_PATH}/_posts/ --assets-dir=#{DEMO_PATH}/assets --assets-base-path=/assets"
+      sh "#{BIN_PATH} @miry -v7 #{medup_options}"
+      sh "#{BIN_PATH} jetthoughts -v7 #{medup_options}"
     end
   end
 
-  task serve: %i[demo:jekyll:install demo:jekyll:create demo:medup:sync demo:medup:jekyll_format demo:jekyll:serve]
+  task serve: %i[demo:jekyll:install demo:jekyll:create demo:medup:sync demo:jekyll:serve]
 end
 
 desc "Run overcommit checks"

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -51,6 +51,26 @@ describe "CommandLine", tags: "e2e" do
       FileUtils.rm_rf "tmp/posts"
     end
 
+    it "specifies assets folder" do
+      FileUtils.rm_rf "posts"
+      FileUtils.rm_rf "tmp"
+
+      actual = run_with ["--assets-dir", "./tmp/assets", "-v4", "https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
+      actual[1].should contain(%{Create directory ./posts})
+      actual[1].should contain(%{Create directory ./tmp/assets})
+    end
+
+    it "specifies assets path in the result markdown" do
+      FileUtils.rm_rf "posts"
+      FileUtils.rm_rf "tmp"
+
+      actual = run_with ["--assets-images", "--assets-base-path", "/custom_assets", "-v4", "https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
+      actual[1].should contain(%{Create asset ./posts/assets/0*LZaURw4xtfA74nu9.jpeg})
+      File.open("posts/2020-09-16-medup-backups-articles.md") do |f|
+        f.gets_to_end.should contain(%{/custom_assets/0*LZaURw4xtfA74nu9.jpeg})
+      end
+    end
+
     it "test wrong github api token to access gist" do
       FileUtils.rm_rf "posts"
 

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -44,6 +44,19 @@ describe Medium::Post::Paragraph do
       asset_name.should eq("0*FbFs8aNmqNLKw4BM.png")
     end
 
+    it "renders images with assets custom base path" do
+      subject = Medium::Post::Paragraph.from_json(%{{"name": "78ee", "type": 4, "text": "Photo", "layout": 3, "metadata":{"id":"0*FbFs8aNmqNLKw4BM"}, "markups": []}})
+      settings = ::Medup::Settings.new
+      settings.set_assets_image!
+      settings.assets_base_path = "/custom_assets"
+      ctx = ::Medup::Context.new(settings)
+
+      content, asset_name, assets = subject.to_md(ctx)
+      content.should eq("![Photo](/custom_assets/0*FbFs8aNmqNLKw4BM.png)")
+      assets.size.should eq(66)
+      asset_name.should eq("0*FbFs8aNmqNLKw4BM.png")
+    end
+
     it "render number list" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 10, "text": "it should be cross distributive solution", "markups": []}})
       subject.to_md[0].should eq("1. it should be cross distributive solution")

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -36,6 +36,7 @@ module Medium
         content : String = ""
         assets = ""
         asset_name = ""
+        assets_base_path = settings.assets_base_path
         content = case @type
                   when 1
                     markup
@@ -51,9 +52,9 @@ module Medium
                       if settings.assets_image?
                         assets = asset_body
                         if @href
-                          "[![#{@text}](./assets/#{asset_name})](#{@href})"
+                          "[![#{@text}](#{assets_base_path}/#{asset_name})](#{@href})"
                         else
-                          "![#{@text}](./assets/#{asset_name})"
+                          "![#{@text}](#{assets_base_path}/#{asset_name})"
                         end
                       else
                         assets = "[image_ref_#{asset_id}]: data:#{asset_type};base64,"

--- a/src/medup/settings.cr
+++ b/src/medup/settings.cr
@@ -2,8 +2,15 @@ require "./options"
 
 module Medup
   struct Settings
+    DEFAULT_ASSETS_DIR_NAME  = "assets"
+    DEFAULT_POSTS_PATH       = "./posts"
+    DEFAULT_ASSETS_BASE_PATH = "./assets"
+
     property medium_token : String?
     property github_api_token : String?
+    property posts_dist : String = DEFAULT_POSTS_PATH
+    setter assets_dist : String?
+    property assets_base_path : String = DEFAULT_ASSETS_BASE_PATH
     property options : Array(::Medup::Options) = Array(Medup::Options).new
 
     def initialize
@@ -23,6 +30,10 @@ module Medup
 
     def assets_image? : Bool
       @options.includes? ::Medup::Options::ASSETS_IMAGE
+    end
+
+    def assets_dist : String
+      @assets_dist ||= File.join(@posts_dist, DEFAULT_ASSETS_DIR_NAME)
     end
   end
 end

--- a/src/medup/tool.cr
+++ b/src/medup/tool.cr
@@ -4,7 +4,6 @@ require "logger"
 
 module Medup
   class Tool
-    DIST_PATH                = "./posts"
     ASSETS_DIR_NAME          = "assets"
     SOURCE_AUTHOR_POSTS      = "overview"
     SOURCE_RECOMMENDED_POSTS = "has-recommended"
@@ -20,7 +19,6 @@ module Medup
 
     def initialize(
       @ctx : ::Medup::Context = ::Medup::Context.new,
-      dist : String? = DIST_PATH,
       format : String? = MARKDOWN_FORMAT,
       source : String? = SOURCE_AUTHOR_POSTS,
       @user : String? = nil,
@@ -30,8 +28,10 @@ module Medup
       @logger = @ctx.logger
       @client = Medium::Client.new(@user, @publication, @logger)
       Medium::Client.default = @client
-      @dist = (dist || DIST_PATH).as(String)
-      @assets_dist = File.join(@dist, ASSETS_DIR_NAME)
+
+      @dist = @ctx.settings.posts_dist
+      @assets_dist = @ctx.settings.assets_dist
+
       @source = (source || SOURCE_AUTHOR_POSTS).as(String)
       @format = (format || MARKDOWN_FORMAT).as(String)
       @update = @ctx.settings.update_content?


### PR DESCRIPTION
Jekyll put assets in another directory from posts. 
Need to support command line option to specify a folder.

Allow to update the url path to assets to support different path to assets instead of relative.


Add command lines arguments: `--assets-dir` and `--assets-base-path`.
It allows to change the distination of assets and
URI links base paths.

Example:

```shell
$ medup --assets-dir="_assets" --assets-base-path="/assets" @miry
```