### PR TITLE
Remove extra symbols from author name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Tags is an array instead of list of words splitted with coma
+- Tags is an array instead of the list of words split with coma. (@miry)
+
+### Fixed
+- Overlapping style and link tags could produce an incredible Markdown.
+  Because of WYSIWYG, plenty of hidden things that could destroy Markdown.
+  Introduce a workaround to have swap places last space and closing elements.
+  Ignore links without anchor text.
+  There are still more possibilities to break Markdown. (#59, @miry)
 
 ## [0.7.0] - 2022-07-22
 ### Changed

--- a/spec/e2e/cli.cr
+++ b/spec/e2e/cli.cr
@@ -90,6 +90,20 @@ describe "CommandLine", tags: "e2e" do
       FileUtils.rm_rf "posts"
     end
 
+    it "parse complex content with overlapped styles" do
+      FileUtils.rm_rf "posts"
+
+      actual = run_with ["--assets-images", "--assets-base-path", "/custom_assets", "-v4", "https://medium.com/notes-and-tips-in-full-stack-development/medup-backups-articles-8bf90179b094"]
+      actual[1].should contain(%{Create asset ./posts/assets/0*LZaURw4xtfA74nu9.jpeg})
+
+      content = File.read("posts/2020-09-16-medup-backups-articles.md")
+      content.should contain <<-CONTENT
+      ***Paul Keen** is a Chief Technology Officer at [JetThoughts](https://www.jetthoughts.com). Follow him on* [LinkedIn](https://www.linkedin.com/in/paul-keen/) *or [GitHub](https://github.com/pftg).*
+      CONTENT
+
+      FileUtils.rm_rf "posts"
+    end
+
     it "test wrong github api token to access gist" do
       FileUtils.rm_rf "posts"
 

--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -101,6 +101,223 @@ describe Medium::Post::Paragraph do
       subject.to_md[0].should eq("### [🇺🇦 JetThoughts](https://jtway.co/resize-amazon-ebs-volumes-without-a-reboot-ca118b010b44): REsize Amazon EBS volumes without a reboot")
     end
 
+    it "ignore links with empty title" do
+      entity_raw = <<-JSON
+        {
+          "name": "5801",
+          "type": 1,
+          "text": "Paul Keen is a Chief Technology Officer at JetThoughts. Follow him on LinkedIn or GitHub.",
+          "markups": [
+            {
+              "type": 3,
+              "start": 69,
+              "end": 70,
+              "href": "https://twitter.com/someone",
+              "title": "",
+              "rel": "nofollow noopener noopener noopener noopener noopener",
+              "anchorType": 0
+            }
+          ]
+        }
+      JSON
+      subject = Medium::Post::Paragraph.from_json(entity_raw)
+      subject.to_md[0].should eq("Paul Keen is a Chief Technology Officer at JetThoughts. Follow him on LinkedIn or GitHub.")
+    end
+
+    it "swap space with close tag" do
+      entity_raw = <<-JSON
+        {
+          "name": "5801",
+          "type": 1,
+          "text": "Paul Keen is a ...",
+          "markups": [
+            {
+              "type": 1,
+              "start": 0,
+              "end": 10
+            }
+          ]
+        }
+      JSON
+      subject = Medium::Post::Paragraph.from_json(entity_raw)
+      subject.to_md[0].should eq("**Paul Keen** is a ...")
+    end
+
+    describe "renders complex sentence with mix italic, bold and links" do
+      it "apply first link not overlapped" do
+        entity_raw = <<-JSON
+          {
+            "name": "5801",
+            "type": 1,
+            "text": "Paul Keen is a Chief Technology Officer at JetThoughts. Follow him on LinkedIn or GitHub.",
+            "markups": [
+              {
+                "type": 3,
+                "start": 43,
+                "end": 54,
+                "href": "https://www.jetthoughts.com",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 69,
+                "end": 70,
+                "href": "https://twitter.com/ChrisKeathley",
+                "title": "",
+                "rel": "nofollow noopener noopener noopener noopener noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 70,
+                "end": 78,
+                "href": "https://www.linkedin.com/in/paul-keen/",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 82,
+                "end": 88,
+                "href": "https://github.com/pftg",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              }
+            ]
+          }
+        JSON
+
+        subject = Medium::Post::Paragraph.from_json(entity_raw)
+        subject.to_md[0].should eq("Paul Keen is a Chief Technology Officer at [JetThoughts](https://www.jetthoughts.com). Follow him on [LinkedIn](https://www.linkedin.com/in/paul-keen/) or [GitHub](https://github.com/pftg).")
+      end
+
+      it "apply links with bold not overlapped" do
+        entity_raw = <<-JSON
+          {
+            "name": "5801",
+            "type": 1,
+            "text": "Paul Keen is a Chief Technology Officer at JetThoughts. Follow him on LinkedIn or GitHub.",
+            "markups": [
+              {
+                "type": 3,
+                "start": 43,
+                "end": 54,
+                "href": "https://www.jetthoughts.com",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 69,
+                "end": 70,
+                "href": "https://twitter.com/ChrisKeathley",
+                "title": "",
+                "rel": "nofollow noopener noopener noopener noopener noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 70,
+                "end": 78,
+                "href": "https://www.linkedin.com/in/paul-keen/",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 82,
+                "end": 88,
+                "href": "https://github.com/pftg",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 1,
+                "start": 0,
+                "end": 10
+              }
+            ]
+          }
+        JSON
+
+        subject = Medium::Post::Paragraph.from_json(entity_raw)
+        subject.to_md[0].should eq("**Paul Keen** is a Chief Technology Officer at [JetThoughts](https://www.jetthoughts.com). Follow him on [LinkedIn](https://www.linkedin.com/in/paul-keen/) or [GitHub](https://github.com/pftg).")
+      end
+
+      it "apply links and styles overlapped" do
+        entity_raw = <<-JSON
+          {
+            "name": "5801",
+            "type": 1,
+            "text": "Paul Keen is a Chief Technology Officer at JetThoughts. Follow him on LinkedIn or GitHub.",
+            "markups": [
+              {
+                "type": 3,
+                "start": 43,
+                "end": 54,
+                "href": "https://www.jetthoughts.com",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 69,
+                "end": 70,
+                "href": "https://twitter.com/ChrisKeathley",
+                "title": "",
+                "rel": "nofollow noopener noopener noopener noopener noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 70,
+                "end": 78,
+                "href": "https://www.linkedin.com/in/paul-keen/",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 3,
+                "start": 82,
+                "end": 88,
+                "href": "https://github.com/pftg",
+                "title": "",
+                "rel": "noopener",
+                "anchorType": 0
+              },
+              {
+                "type": 1,
+                "start": 0,
+                "end": 10
+              },
+              {
+                "type": 2,
+                "start": 0,
+                "end": 70
+              },
+              {
+                "type": 2,
+                "start": 79,
+                "end": 89
+              }
+            ]
+          }
+        JSON
+
+        subject = Medium::Post::Paragraph.from_json(entity_raw)
+        subject.to_md[0].should eq("***Paul Keen** is a Chief Technology Officer at [JetThoughts](https://www.jetthoughts.com). Follow him on* [LinkedIn](https://www.linkedin.com/in/paul-keen/) *or [GitHub](https://github.com/pftg).*")
+      end
+    end
+
     it "render code block" do
       subject = Medium::Post::Paragraph.from_json(%{{"name": "d2a9", "type": 8, "text": "puts hello", "markups": []}})
       subject.to_md[0].should eq("```\nputs hello\n```")


### PR DESCRIPTION
The original post: https://jtway.co/speed-up-your-rails-test-suite-by-6-in-1-line-13fedb869ec4

In medium it looks like

<img width="771" alt="image" src="https://user-images.githubusercontent.com/21104/180766082-86667995-b9e0-4477-bf77-be47a3bdc875.png">

But in Markdown has a single `*` in front of line:

![image](https://user-images.githubusercontent.com/23320186/180664808-c53963f0-40d8-48a3-bae2-1532bd65020b.png)
https://github.com/jetthoughts/blog/blob/master/_posts/2017-06-13-speed-up-your-rails-test-suite-by-6-in-1-line.md

```markdown
***Paul Keen** is a Chief Technology Officer at [JetThoughts](https://www.jetthoughts.com). Follow him on[ *](https://twitter.com/ChrisKeathley)[LinkedIn](https://www.linkedin.com/in/paul-keen/) *or [GitHub](https://github.com/pftg).*
```

For example:
`***Paul Keen **is a Chief Technology Officer ...*` => `**Paul Keen** is a Chief Technology Officer`