### PR TITLE
Second code block marked as quotted

### DIFF
--- a/spec/medium/post/paragraph_spec.cr
+++ b/spec/medium/post/paragraph_spec.cr
@@ -403,6 +403,12 @@ describe Medium::Post::Paragraph do
                     "type": "application/x-sh",
                     "raw_url": "https://gist.githubusercontent.com/",
                     "content": "#!/usr/bin/env bash\\n\\nmedup -u miry -d ./posts/miry"
+                  },
+                  "quux.sh": {
+                    "filename": "quux.sh",
+                    "type": "application/x-sh",
+                    "raw_url": "https://gist.githubusercontent.com/",
+                    "content": "#!/usr/bin/env bash\\n\\nmedup jetthoughts -d ./posts/jetthoughts"
                   }
                 }}
               },
@@ -417,8 +423,21 @@ describe Medium::Post::Paragraph do
               }
             }
           })
-          subject.to_md[0].should contain(%{medup -u miry -d ./posts/miry})
-          subject.to_md[0].should contain(%{[usage.sh view raw](https:})
+          subject.to_md[0].should contain <<-CONTENT
+          ```
+          #!/usr/bin/env bash
+
+          medup -u miry -d ./posts/miry
+          ```
+          > *[usage.sh view raw](https://gist.githubusercontent.com/)*
+
+          ```
+          #!/usr/bin/env bash
+
+          medup jetthoughts -d ./posts/jetthoughts
+          ```
+          > *[quux.sh view raw](https://gist.githubusercontent.com/)*
+          CONTENT
         end
 
         it "render media gist inline without thumbnailUrl" do

--- a/src/medium/post/paragraph.cr
+++ b/src/medium/post/paragraph.cr
@@ -244,9 +244,9 @@ module Medium
         return "" if gists.nil?
 
         return gists.map do |gist|
-          "```\n#{gist["content"]}\n```\n" +
-            "> *[#{gist["filename"]} view raw](#{gist["raw_url"]})*"
-        end.join("\n")
+          "```\n#{gist["content"]}\n```\n" \
+          "> *[#{gist["filename"]} view raw](#{gist["raw_url"]})*"
+        end.join("\n\n")
       end
 
       def process_twitter_content(content : String) : String


### PR DESCRIPTION
Original: https://jtway.co/setup-k8s-v1-6-0-rc-1-cluster-b4cc7749973f
<img width="791" alt="image" src="https://user-images.githubusercontent.com/21104/181002165-7ace4b1b-9ec9-4caa-a17f-2c57e62607dc.png">

Rendered: https://miry.github.io/2017-03-26/setup-k8s-v1-6-0-rc-1-cluster
<img width="943" alt="image" src="https://user-images.githubusercontent.com/21104/181002020-6e5517fb-9f67-4d1f-ac4b-ff975f73abe8.png">

It is required an empty line between gists.